### PR TITLE
Update NEURON dependency to resolve compatibility issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ murmurhash==1.0.11
 namex==0.0.8
 nest-asyncio==1.6.0
 networkx==3.2.1
-NEURON==8.2.0
+NEURON==8.2.4
 nltk==3.9.1
 numpy==2.0.2
 openai==1.55.1


### PR DESCRIPTION
This change updates NEURON from the previous version to `NEURON==8.2.4`. 
Version `8.2.4` was tested successfully on macOS and in GitHub Codespaces (Linux). 
It resolves installation issues caused by the previous version, ensuring cross-platform compatibility.

<img width="885" alt="Снимок экрана 2025-01-10 в 00 13 57" src="https://github.com/user-attachments/assets/bb0c6571-6301-4716-830f-cab888cd9ba5" />
