### PR TITLE
Fix of checkpoint command mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ When resources are limited, **optimize by fine-tuning smaller models** on your s
 
 **If you lose progress, internet connection, or if a subtask fails, you can always load from a previous state.** All of your progress is saved by default in the `state_saves` variable, which stores each individual checkpoint. Just pass the following arguments when running `ai_lab_repo.py`
 
-`python ai_lab_repo.py --api-key "API_KEY_HERE" --research-topic "YOUR RESEARCH IDEA" --llm-backend "o1-mini" --load-existing True --load-existing-path "save_states/LOAD_PATH"`
+`python ai_lab_repo.py --api-key "API_KEY_HERE" --research-topic "YOUR RESEARCH IDEA" --llm-backend "o1-mini" --load-existing True --load-existing-path "state_saves/LOAD_PATH"`
 
 -----
 


### PR DESCRIPTION
Fixing a very important folder designation typo when working with checkpoints