### PR TITLE
Add support for custom OpenAI API base_url

### DIFF
--- a/ai_lab_repo.py
+++ b/ai_lab_repo.py
@@ -11,7 +11,7 @@ DEFAULT_LLM_BACKBONE = "o1-mini"
 
 
 class LaboratoryWorkflow:
-    def __init__(self, research_topic, openai_api_key, max_steps=100, num_papers_lit_review=5, agent_model_backbone=f"{DEFAULT_LLM_BACKBONE}", notes=list(), human_in_loop_flag=None, compile_pdf=True, mlesolver_max_steps=3, papersolver_max_steps=5):
+    def __init__(self, research_topic, openai_api_key, max_steps=100, num_papers_lit_review=5, agent_model_backbone=f"{DEFAULT_LLM_BACKBONE}", notes=list(), human_in_loop_flag=None, compile_pdf=True, mlesolver_max_steps=3, papersolver_max_steps=5, openai_base_url="https://api.openai.com/v1"):
         """
         Initialize laboratory workflow
         @param research_topic: (str) description of research idea to explore
@@ -28,6 +28,7 @@ class LaboratoryWorkflow:
         self.research_topic = research_topic
         self.model_backbone = agent_model_backbone
         self.num_papers_lit_review = num_papers_lit_review
+        self.openai_base_url = openai_base_url
 
         self.print_cost = True
         self.review_override = True # should review be overridden?
@@ -570,6 +571,13 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        '--base-url',
+        type=str,
+        default="https://api.openai.com/v1",
+        help='Base URL for OpenAI API.'
+    )
+
+    parser.add_argument(
         '--compile-latex',
         type=str,
         default="True",
@@ -646,6 +654,11 @@ if __name__ == "__main__":
     if not api_key and not deepseek_api_key:
         raise ValueError("API key must be provided via --api-key / -deepseek-api-key or the OPENAI_API_KEY / DEEPSEEK_API_KEY environment variable.")
 
+    base_url = os.getenv('OPENAI_BASE_URL') or args.base_url
+    if args.base_url is not None and os.getenv('OPENAI_BASE_URL') is None:
+        os.environ["OPENAI_BASE_URL"] = args.base_url
+
+    
     ##########################################################
     # Research question that the agents are going to explore #
     ##########################################################
@@ -662,7 +675,7 @@ if __name__ == "__main__":
          "note": "Please use gpt-4o-mini for your experiments."},
 
         {"phases": ["running experiments"],
-         "note": f'Use the following code to inference gpt-4o-mini: \nfrom openai import OpenAI\nos.environ["OPENAI_API_KEY"] = "{api_key}"\nclient = OpenAI()\ncompletion = client.chat.completions.create(\nmodel="gpt-4o-mini-2024-07-18", messages=messages)\nanswer = completion.choices[0].message.content\n'},
+         "note": f'Use the following code to inference gpt-4o-mini: \nfrom openai import OpenAI\nos.environ["OPENAI_API_KEY"] = "{api_key}"\nopenai.base_url = {base_url}\nclient = OpenAI()\ncompletion = client.chat.completions.create(\nmodel="gpt-4o-mini-2024-07-18", messages=messages)\nanswer = completion.choices[0].message.content\n'},
 
         {"phases": ["running experiments"],
          "note": f"You have access to only gpt-4o-mini using the OpenAI API, please use the following key {api_key} but do not use too many inferences. Do not use openai.ChatCompletion.create or any openai==0.28 commands. Instead use the provided inference code."},
@@ -725,6 +738,7 @@ if __name__ == "__main__":
             num_papers_lit_review=num_papers_lit_review,
             papersolver_max_steps=papersolver_max_steps,
             mlesolver_max_steps=mlesolver_max_steps,
+            openai_base_url=base_url
         )
 
     lab.perform_research()

--- a/inference.py
+++ b/inference.py
@@ -40,6 +40,8 @@ def query_model(model_str, prompt, system_prompt, openai_api_key=None, anthropic
         os.environ["OPENAI_API_KEY"] = openai_api_key
     if anthropic_api_key is not None:
         os.environ["ANTHROPIC_API_KEY"] = anthropic_api_key
+    base_url = os.getenv('OPENAI_BASE_URL', 'https://api.openai.com/v1')
+    openai.base_url = base_url
     for _ in range(tries):
         try:
             if model_str == "gpt-4o-mini" or model_str == "gpt4omini" or model_str == "gpt-4omini" or model_str == "gpt4o-mini":


### PR DESCRIPTION
**Description:**
This Pull Request addresses [Issue #37](https://github.com/SamuelSchmidgall/AgentLaboratory/issues/37), which requests support for customizing the OpenAI API base_url. Previously, the project defaulted to https://api.openai.com/v1, which caused issues for users who need to route their API requests through proxies or alternate endpoints.

This enhancement introduces a new parameter for setting the base_url. The base_url can now be configured in two ways:
1. Environment Variable: Using `OPENAI_BASE_URL`.
2. Command-line Argument: Via the '--base-url' parameter when running `ai_lab_repo.py`.

If no custom base_url is provided, the project will default to the official OpenAI API URL (https://api.openai.com/v1), ensuring backward compatibility.

**Key Changes:**
* Added base_url configuration with a default fallback to https://api.openai.com/v1.
* Used the following code for reading and applying the base_url at `Inference.py`:
```python
import os
import openai

# Fetch custom base URL from environment or use the default
base_url = os.getenv('OPENAI_BASE_URL', 'https://api.openai.com/v1')
openai.api_base = base_url
```
* Updated `ai_lab_repo.py` to include the `--base-url` parameter for command-line usage. And set environment variables `OPENAI_BASE_URL`.

**Testing:**
1. Default behavior:
Ensure the API works as expected without specifying a custom base_url.
```bash
python ai_lab_repo.py --api-key "API_KEY_HERE" --llm-backend "o1-mini" --research-topic "YOUR RESEARCH IDEA"
```
2. Using a custom base URL:
* Test with a custom base_url parameter:
```bash
python ai_lab_repo.py --api-key "API_KEY_HERE" --llm-backend "o1-mini" --research-topic "YOUR RESEARCH IDEA" --base-url "YOUR CUSTOM BASE URL"
```
* Test with environment variable configuration:
Set OPENAI_BASE_URL and test without the --base-url parameter:
```bash
export OPENAI_BASE_URL="http://localhost:8080/v1"
python ai_lab_repo.py --api-key "API_KEY_HERE" --llm-backend "o1-mini" --research-topic "YOUR RESEARCH IDEA"
```

**Who Benefits:**
	•	Users in restricted regions: Customizing base_url allows routing through proxies.
	•	Developers and organizations: Enables compliance with internal routing policies.
	•	Advanced users: Provides flexibility for testing or specialized configurations.

_Backward Compatibility:_
**The changes are fully backward-compatible. If no custom base_url is provided, the project defaults to using the official OpenAI API URL.**

Thank you for reviewing this contribution! Please let me know if any adjustments or additional documentation are required. 😊