### PR TITLE
fix double-assignment

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -263,7 +263,7 @@ class BaseAgent:
         # remove histories that have expiration dates
         for _i in reversed(range(len(self.history))):
             if self.history[_i][0] is not None:
-                self.history[_i] = self.history[_i] = self.history[_i][0] - 1, self.history[_i][1]
+                self.history[_i] = (self.history[_i][0] - 1, self.history[_i][1])
                 if self.history[_i][0] < 0:
                     self.history.pop(_i)
         if len(self.history) >= self.max_hist_len:


### PR DESCRIPTION
existing code:
`self.history[_i] = self.history[_i] = self.history[_i][0] - 1, self.history[_i][1]`

The code is trying to update a tuple in the history list where:
- self.history[_i][0] is the expiration counter (number of steps until this history entry expires)
- self.history[_i][1] is the actual history content

The intention is to:
- Decrement the expiration counter by 1
- Keep the same history content
- Store the new tuple back in the list

The current line has a double assignment (`self.history[_i] = self.history[_i] = ...`) which is unnecessary and could potentially cause issues.

The fix removes one assignment and wraps the new tuple in parentheses for clarity, though they're optional in this case since the comma creates a tuple automatically.

```
# Current problematic line
self.history[_i] = self.history[_i] = self.history[_i][0] - 1, self.history[_i][1]

# Should be simplified to
self.history[_i] = (self.history[_i][0] - 1, self.history[_i][1])
```